### PR TITLE
Fix class name + parameter

### DIFF
--- a/lib/DoctrineExtensions/NestedSet/NodeWrapper.php
+++ b/lib/DoctrineExtensions/NestedSet/NodeWrapper.php
@@ -1282,9 +1282,9 @@ class NodeWrapper implements Node
             // Prepare left & right query
             $metadata = $em->getClassMetadata(get_class($this->getNode()));
             $q = $em->createQueryBuilder()            
-            ->update($metadata->rootEntityName, 'n')
-            ->set("n.$field", "n.$field + :delta")
-            ->setParameter('delta', $delta)
+            ->update($metadata->name, 'n')
+            ->set("n.$field", ":delta")
+            ->setParameter('delta', "n.$field + $delta")
             ->where("n.$field >= :lowerbound")
             ->setParameter('lowerbound', $first);
 


### PR DESCRIPTION
Fix 2 problems we run through :

* Incorrect use of rootEntityName, leading request on parent entity not mapping the required tree properties
* Incorrect definition of parameter leading Doctrine to use '?' instead of the expected value